### PR TITLE
Fixed display of inline fields on a for which uses the editor

### DIFF
--- a/django_admin_json_editor/static/django_admin_json_editor/style.css
+++ b/django_admin_json_editor/static/django_admin_json_editor/style.css
@@ -14,3 +14,7 @@ div.sceditor-container {
 ul li {
     list-style-type: none;
 }
+
+.js-inline-admin-formset fieldset.module {
+    box-sizing: content-box;
+}


### PR DESCRIPTION
Just a small adjustment as we have an inline form for sales channel delivery providers below the fields. I think it is good enough for now. 